### PR TITLE
Add comprehensive tests and fix task and graph behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+/.pytest_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- Run `pytest` before finishing any change.
+- Prefer clear, well-documented code and add or update docstrings when introducing or modifying public functions.
+- Maintain existing formatting and follow PEP 8 standards.

--- a/graph_space_v2/core/graph/knowledge_graph.py
+++ b/graph_space_v2/core/graph/knowledge_graph.py
@@ -891,19 +891,35 @@ class KnowledgeGraph:
         # Find and remove the entity from our data collections
         entity_found = False
 
+        original_counts = {
+            "notes": len(self.data.get("notes", [])),
+            "tasks": len(self.data.get("tasks", [])),
+            "contacts": len(self.data.get("contacts", [])),
+        }
+
         # Try to find and remove from notes
-        self.data["notes"] = [note for note in self.data["notes"]
-                              if note.get("id") != entity_id]
+        self.data["notes"] = [
+            note for note in self.data["notes"]
+            if note.get("id") != entity_id
+        ]
+        if len(self.data["notes"]) < original_counts["notes"]:
+            entity_found = True
 
         # Try to find and remove from tasks
-        self.data["tasks"] = [task for task in self.data["tasks"]
-                              if task.get("id") != entity_id]
+        self.data["tasks"] = [
+            task for task in self.data["tasks"]
+            if task.get("id") != entity_id
+        ]
+        if len(self.data["tasks"]) < original_counts["tasks"]:
+            entity_found = True
 
         # Try to find and remove from contacts
-        orig_contact_count = len(self.data["contacts"])
-        self.data["contacts"] = [contact for contact in self.data["contacts"]
-                                 if contact.get("id") != entity_id]
-        entity_found = len(self.data["contacts"]) < orig_contact_count
+        self.data["contacts"] = [
+            contact for contact in self.data["contacts"]
+            if contact.get("id") != entity_id
+        ]
+        if len(self.data["contacts"]) < original_counts["contacts"]:
+            entity_found = True
 
         if not entity_found:
             return False

--- a/graph_space_v2/core/models/task.py
+++ b/graph_space_v2/core/models/task.py
@@ -183,7 +183,12 @@ class Task(BaseModel):
             return None
 
         # Parse the start date
-        start_date = self.due_date or self.recurrence_start_date or datetime.now().isoformat()
+        start_date = (
+            self.recurrence_next_run
+            or self.due_date
+            or self.recurrence_start_date
+            or datetime.now().isoformat()
+        )
 
         try:
             base_date = datetime.fromisoformat(start_date)

--- a/graph_space_v2/core/services/task_service.py
+++ b/graph_space_v2/core/services/task_service.py
@@ -21,7 +21,10 @@ class TaskService:
         self.llm_service = llm_service
 
     def add_task(self, task_data: Dict[str, Any]) -> str:
-        if not isinstance(task_data, Task):
+        if isinstance(task_data, Task):
+            task = task_data
+            task_data = task.to_dict()
+        else:
             # Generate title using LLM if available and not provided
             if self.llm_service and not task_data.get("title") and task_data.get("description"):
                 title = self.llm_service.generate_title(
@@ -63,16 +66,17 @@ class TaskService:
 
         return None
 
-    def get_all_tasks(self) -> List[Dict[str, Any]]:
-        """
-        Get all tasks as dictionaries instead of Task objects.
+    def get_all_tasks(self) -> List[Task]:
+        """Return every stored task as a :class:`Task` instance.
 
         Returns:
-            List of task dictionaries
+            List[Task]: Concrete task models loaded from the knowledge graph.
         """
-        return [task.to_dict() for task in
-                [Task.from_dict(task_data) for task_data in
-                 self.knowledge_graph.data.get("tasks", [])]]
+
+        return [
+            Task.from_dict(task_data)
+            for task_data in self.knowledge_graph.data.get("tasks", [])
+        ]
 
     def update_task(self, task_id: str, task_data: Dict[str, Any]) -> Optional[Task]:
         # Set the updated_at timestamp

--- a/graph_space_v2/graphspace.py
+++ b/graph_space_v2/graphspace.py
@@ -194,8 +194,8 @@ class GraphSpace:
         return self.task_service.add_task(task_data)
 
     def get_tasks(self):
-        """Get all tasks."""
-        return self.task_service.get_all_tasks()
+        """Get all tasks as serializable dictionaries."""
+        return [task.to_dict() for task in self.task_service.get_all_tasks()]
 
     def get_task(self, task_id: str):
         """Get a task by ID."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,184 @@
+"""Pytest fixtures and stubs for GraphSpace v2 tests."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import types
+
+import numpy as np
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:  # pragma: no branch - executes once during import
+    sys.path.insert(0, str(ROOT))
+
+if "dotenv" not in sys.modules:  # pragma: no branch - ensures optional dependency
+    dotenv_module = types.ModuleType("dotenv")
+    dotenv_module.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = dotenv_module
+
+if "torch" not in sys.modules:  # pragma: no branch - avoid heavy dependency
+    torch_module = types.ModuleType("torch")
+
+    class _Cuda:
+        @staticmethod
+        def is_available() -> bool:  # pragma: no cover - simple stub
+            return False
+
+    torch_module.cuda = _Cuda()
+    sys.modules["torch"] = torch_module
+
+if "sentence_transformers" not in sys.modules:  # pragma: no branch
+    st_module = types.ModuleType("sentence_transformers")
+
+    class _SentenceTransformer:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - trivial stub
+            pass
+
+        def encode(self, texts, convert_to_tensor=False):  # pragma: no cover
+            if isinstance(texts, list):
+                return np.zeros((len(texts), 1), dtype=np.float32)
+            return np.zeros((1,), dtype=np.float32)
+
+    st_module.SentenceTransformer = _SentenceTransformer
+    sys.modules["sentence_transformers"] = st_module
+
+if "faiss" not in sys.modules:  # pragma: no branch
+    faiss_module = types.ModuleType("faiss")
+
+    class _IndexFlatL2:
+        def __init__(self, dimension: int):  # pragma: no cover
+            self.dimension = dimension
+
+        def reset(self) -> None:  # pragma: no cover
+            pass
+
+        def add_with_ids(self, embeddings, ids) -> None:  # pragma: no cover
+            pass
+
+        def search(self, queries, k):  # pragma: no cover
+            return np.zeros((len(queries), k)), np.zeros((len(queries), k))
+
+    class _IndexIDMap:
+        def __init__(self, index):  # pragma: no cover
+            self.index = index
+
+    def normalize_L2(vectors):  # pragma: no cover
+        return vectors
+
+    faiss_module.IndexFlatL2 = _IndexFlatL2
+    faiss_module.IndexIDMap = _IndexIDMap
+    faiss_module.normalize_L2 = normalize_L2
+    sys.modules["faiss"] = faiss_module
+
+    contrib_module = types.ModuleType("faiss.contrib")
+    torch_utils_module = types.ModuleType("faiss.contrib.torch_utils")
+    torch_utils_module.using_gpu = False
+    sys.modules["faiss.contrib"] = contrib_module
+    sys.modules["faiss.contrib.torch_utils"] = torch_utils_module
+
+from graph_space_v2.core.graph.knowledge_graph import KnowledgeGraph
+
+
+@pytest.fixture()
+def data_file(tmp_path: Path) -> Path:
+    """Create an isolated user data file for a test case."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    data_path = data_dir / "user_data.json"
+    data = {"notes": [], "tasks": [], "contacts": [], "documents": []}
+    data_path.write_text(json.dumps(data))
+    return data_path
+
+
+@pytest.fixture()
+def knowledge_graph(data_file: Path) -> KnowledgeGraph:
+    """Provide a fresh knowledge graph backed by a temporary file."""
+    return KnowledgeGraph(str(data_file))
+
+
+class DummyEmbeddingService:
+    """In-memory embedding service used to isolate tests from heavy models."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.stored_embeddings: Dict[str, Dict[str, Any]] = {}
+        self.updated_embeddings: Dict[str, Any] = {}
+        self.deleted_embeddings: List[str] = []
+        self.semantic_matches: List[Dict[str, Any]] = []
+        self.trained_graph_nodes: List[str] | None = None
+
+    def embed_text(self, text: str) -> str:
+        return f"embedding:{text}"
+
+    def embed_texts(self, texts: List[str]) -> List[str]:
+        return [self.embed_text(text) for text in texts]
+
+    def store_embedding(self, item_id: str, embedding: Any, metadata: Dict[str, Any] | None = None) -> None:
+        self.stored_embeddings[item_id] = {
+            "embedding": embedding,
+            "metadata": metadata or {},
+        }
+
+    def update_embedding(self, item_id: str, embedding: Any, metadata: Dict[str, Any] | None = None) -> bool:
+        self.updated_embeddings[item_id] = {
+            "embedding": embedding,
+            "metadata": metadata or {},
+        }
+        return True
+
+    def delete_embedding(self, item_id: str) -> bool:
+        self.deleted_embeddings.append(item_id)
+        return True
+
+    def search_embeddings(self, query_embedding: Any, filter_metadata: Dict[str, Any] | None = None, limit: int = 5) -> List[Dict[str, Any]]:
+        return self.semantic_matches[:limit]
+
+    def search(self, query_embedding: Any, max_results: int, filter_by: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return {"matches": self.semantic_matches[:max_results]}
+
+    def train_on_graph(self, graph) -> None:  # pragma: no cover - used for integration wiring
+        self.trained_graph_nodes = list(graph.nodes)
+
+
+class DummyLLMService:
+    """Simple LLM stub that records invocations for assertions."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.generated_titles: List[str] = []
+        self.tag_inputs: List[str] = []
+
+    def generate_title(self, text: str) -> str:
+        self.generated_titles.append(text)
+        return f"Title for {text[:10]}".strip()
+
+    def extract_tags(self, text: str) -> List[str]:
+        self.tag_inputs.append(text)
+        return ["llm-tag", "auto"]
+
+    def generate_summary(self, text: str) -> str:  # pragma: no cover - document processing stub
+        return text[:50]
+
+    def extract_entities(self, text: str) -> Dict[str, Any]:  # pragma: no cover
+        return {"entities": []}
+
+    def generate_text(self, *args: Any, **kwargs: Any) -> str:  # pragma: no cover
+        return "generated"
+
+    def generate_answer(self, *args: Any, **kwargs: Any) -> str:  # pragma: no cover
+        return "answer"
+
+
+@pytest.fixture()
+def dummy_embedding_service() -> DummyEmbeddingService:
+    """Fixture exposing a fresh embedding stub per test."""
+    return DummyEmbeddingService()
+
+
+@pytest.fixture()
+def dummy_llm_service() -> DummyLLMService:
+    """Fixture exposing a fresh LLM stub per test."""
+    return DummyLLMService()

--- a/tests/test_graphspace.py
+++ b/tests/test_graphspace.py
@@ -1,0 +1,247 @@
+"""Integration-level checks for the GraphSpace façade."""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import DummyEmbeddingService, DummyLLMService
+
+
+def _install_google_stubs() -> None:
+    """Install minimal Google client stubs so imports succeed during tests."""
+    if "google" not in sys.modules:
+        sys.modules["google"] = types.ModuleType("google")
+
+    credentials_module = types.ModuleType("google.oauth2.credentials")
+
+    class Credentials:
+        def __init__(self) -> None:  # pragma: no cover - simple stub
+            self.token = "token"
+            self.refresh_token = "refresh"
+            self.token_uri = "token_uri"
+            self.client_id = "client"
+            self.client_secret = "secret"
+            self.scopes: list[str] = []
+            self.expiry = None
+            self.valid = True
+            self.expired = False
+
+        @classmethod
+        def from_authorized_user_info(cls, info, scopes):  # pragma: no cover
+            creds = cls()
+            creds.scopes = scopes or []
+            return creds
+
+        def refresh(self, request) -> None:  # pragma: no cover
+            self.expired = False
+            self.valid = True
+
+    credentials_module.Credentials = Credentials
+    sys.modules["google.oauth2.credentials"] = credentials_module
+    sys.modules.setdefault("google.oauth2", types.ModuleType("google.oauth2"))
+
+    flow_module = types.ModuleType("google_auth_oauthlib.flow")
+
+    class InstalledAppFlow:
+        @classmethod
+        def from_client_secrets_file(cls, *args, **kwargs):  # pragma: no cover
+            return cls()
+
+        def run_local_server(self, port: int = 0):  # pragma: no cover
+            return Credentials()
+
+    flow_module.InstalledAppFlow = InstalledAppFlow
+    sys.modules["google_auth_oauthlib.flow"] = flow_module
+
+    requests_module = types.ModuleType("google.auth.transport.requests")
+
+    class Request:  # pragma: no cover - unused stub
+        pass
+
+    requests_module.Request = Request
+    sys.modules["google.auth.transport.requests"] = requests_module
+
+    discovery_module = types.ModuleType("googleapiclient.discovery")
+
+    class _Files:
+        def list(self, **kwargs):  # pragma: no cover
+            return types.SimpleNamespace(execute=lambda: {"files": [], "nextPageToken": None})
+
+        def get(self, **kwargs):  # pragma: no cover
+            return types.SimpleNamespace(execute=lambda: {"mimeType": "application/pdf", "name": "file"})
+
+        def get_media(self, **kwargs):  # pragma: no cover
+            return types.SimpleNamespace()
+
+        def export_media(self, **kwargs):  # pragma: no cover
+            return types.SimpleNamespace()
+
+    class _Service:
+        def files(self):  # pragma: no cover
+            return _Files()
+
+    def build(*args, **kwargs):  # pragma: no cover
+        return _Service()
+
+    discovery_module.build = build
+    discovery_module.Resource = object
+    sys.modules["googleapiclient.discovery"] = discovery_module
+
+    http_module = types.ModuleType("googleapiclient.http")
+
+    class MediaIoBaseDownload:
+        def __init__(self, fh, request) -> None:  # pragma: no cover
+            self._done = False
+
+        def next_chunk(self):  # pragma: no cover
+            if self._done:
+                return (types.SimpleNamespace(progress=1.0), True)
+            self._done = True
+            return (types.SimpleNamespace(progress=1.0), True)
+
+    http_module.MediaIoBaseDownload = MediaIoBaseDownload
+    sys.modules["googleapiclient.http"] = http_module
+
+
+def _install_calendar_stubs() -> None:
+    """Provide lightweight calendar provider stubs."""
+    models_module = types.ModuleType("graph_space_v2.integrations.calendar.models")
+
+    class CalendarEvent:  # pragma: no cover - simple data stub
+        pass
+
+    class Calendar:  # pragma: no cover
+        pass
+
+    models_module.CalendarEvent = CalendarEvent
+    models_module.Calendar = Calendar
+    sys.modules.setdefault("graph_space_v2.integrations.calendar.models", models_module)
+
+    service_module = types.ModuleType("graph_space_v2.integrations.calendar.calendar_service")
+
+    class CalendarService:  # pragma: no cover
+        pass
+
+    service_module.CalendarService = CalendarService
+    sys.modules.setdefault("graph_space_v2.integrations.calendar.calendar_service", service_module)
+
+    task_sync_module = types.ModuleType("graph_space_v2.integrations.calendar.task_sync")
+
+    class TaskCalendarSync:  # pragma: no cover
+        pass
+
+    task_sync_module.TaskCalendarSync = TaskCalendarSync
+    sys.modules.setdefault("graph_space_v2.integrations.calendar.task_sync", task_sync_module)
+
+    providers_module = types.ModuleType("graph_space_v2.integrations.calendar.providers")
+
+    class GoogleCalendarProvider:  # pragma: no cover
+        pass
+
+    class ICalProvider:  # pragma: no cover
+        pass
+
+    providers_module.GoogleCalendarProvider = GoogleCalendarProvider
+    providers_module.ICalProvider = ICalProvider
+    sys.modules.setdefault("graph_space_v2.integrations.calendar.providers", providers_module)
+
+
+def _install_requests_stub() -> None:
+    """Provide a minimal requests module."""
+    if "requests" in sys.modules:
+        return
+
+    requests_module = types.ModuleType("requests")
+
+    class _Response:  # pragma: no cover
+        def __init__(self, status_code: int = 200, content: bytes | None = None):
+            self.status_code = status_code
+            self.content = content or b""
+
+        def json(self):  # pragma: no cover
+            return {}
+
+    def get(*args, **kwargs):  # pragma: no cover
+        return _Response()
+
+    def post(*args, **kwargs):  # pragma: no cover
+        return _Response()
+
+    requests_module.get = get
+    requests_module.post = post
+    requests_module.Response = _Response
+    sys.modules["requests"] = requests_module
+
+
+_install_google_stubs()
+_install_calendar_stubs()
+_install_requests_stub()
+
+
+def _load_graphspace_module():
+    """Import graphspace after stubbing external dependencies."""
+    module = importlib.import_module("graph_space_v2.graphspace")
+    return module, importlib.import_module("graph_space_v2")
+
+
+class DummyDocumentProcessor:
+    """Minimal document processor stub for GraphSpace wiring tests."""
+
+    def __init__(self, llm_service, embedding_service, knowledge_graph):  # pragma: no cover - behaviour not under test
+        self.llm_service = llm_service
+        self.embedding_service = embedding_service
+        self.knowledge_graph = knowledge_graph
+
+
+@pytest.fixture()
+def graphspace_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config.json"
+    config = {
+        "embedding": {"model": "dummy", "dimension": 3},
+        "llm": {"model": "dummy", "fallback_model": "dummy"},
+    }
+    config_path.write_text(json.dumps(config))
+    return config_path
+
+
+@pytest.fixture()
+def user_data(tmp_path: Path) -> Path:
+    data_path = tmp_path / "user_data.json"
+    data = {"notes": [], "tasks": [], "contacts": [], "documents": []}
+    data_path.write_text(json.dumps(data))
+    return data_path
+
+
+@pytest.fixture()
+def patched_graphspace(monkeypatch: pytest.MonkeyPatch, graphspace_config: Path, user_data: Path):
+    """Instantiate GraphSpace with lightweight service stubs."""
+    graphspace_module, _ = _load_graphspace_module()
+    monkeypatch.setattr(graphspace_module, "EmbeddingService", DummyEmbeddingService)
+    monkeypatch.setattr(graphspace_module, "LLMService", DummyLLMService)
+    monkeypatch.setattr(graphspace_module, "DocumentProcessor", DummyDocumentProcessor)
+
+    instance = graphspace_module.GraphSpace(
+        data_path=str(user_data),
+        config_path=str(graphspace_config),
+        use_api=False,
+    )
+    return instance
+
+
+def test_graphspace_adds_and_serializes_tasks(patched_graphspace) -> None:
+    """GraphSpace should expose TaskService through high-level helpers."""
+    task_id = patched_graphspace.add_task({"description": "Plan release"})
+    tasks = patched_graphspace.get_tasks()
+
+    assert tasks[0]["id"] == task_id
+    assert tasks[0]["title"].startswith("Title for")
+
+
+def test_graphspace_lazy_google_drive_service(patched_graphspace) -> None:
+    """Google Drive service should remain None when integration disabled."""
+    assert patched_graphspace.google_drive_service is None

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,134 @@
+"""Knowledge graph storage and relationship tests."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from graph_space_v2.core.graph.knowledge_graph import KnowledgeGraph
+from graph_space_v2.utils.errors.exceptions import EntityNotFoundError
+
+
+def _load_persisted_data(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_add_update_delete_note_persists_changes(knowledge_graph: KnowledgeGraph, data_file: Path) -> None:
+    """Notes should be stored, updated, and deleted both in memory and on disk."""
+    note_id = knowledge_graph.add_note({
+        "title": "Research",
+        "content": "Investigate vector databases",
+        "tags": ["ai", "research"],
+    })
+    assert knowledge_graph.get_note(note_id)["title"] == "Research"
+
+    knowledge_graph.update_note(note_id, {"title": "Updated title"})
+    assert knowledge_graph.get_note(note_id)["title"] == "Updated title"
+
+    persisted = _load_persisted_data(data_file)
+    assert persisted["notes"][0]["title"] == "Updated title"
+
+    assert knowledge_graph.delete_note(note_id) is True
+    assert knowledge_graph.get_note(note_id) is None
+
+
+def test_task_and_note_relationships_support_lookup(knowledge_graph: KnowledgeGraph) -> None:
+    """Shared tags should link notes and tasks and surface via graph queries."""
+    note_id = knowledge_graph.add_note({
+        "title": "Project plan",
+        "content": "Outline tasks for launch",
+        "tags": ["launch"],
+    })
+    task_id = knowledge_graph.add_task({
+        "title": "Launch prep",
+        "description": "Finalize checklist",
+        "tags": ["launch"],
+    })
+
+    related = knowledge_graph.get_related_entities(note_id, "note")
+    assert any(entity["id"] == task_id for entity in related)
+
+    tag_results = knowledge_graph.search_by_tag("launch")
+    found_ids = {result["id"] for result in tag_results}
+    assert {note_id, task_id}.issubset(found_ids)
+
+    path = knowledge_graph.find_path(note_id, "note", task_id, "task")
+    assert [segment["id"] for segment in path][:2] == [note_id, task_id]
+
+
+def test_manual_relationship_creation_updates_graph(knowledge_graph: KnowledgeGraph) -> None:
+    """Explicit relationships should be represented as graph edges."""
+    first = knowledge_graph.add_note({"title": "A", "content": "", "tags": []})
+    second = knowledge_graph.add_note({"title": "B", "content": "", "tags": []})
+
+    created = knowledge_graph.add_relationship(first, second, "linked")
+    assert created is True
+    assert knowledge_graph.graph.has_edge(f"note_{first}", f"note_{second}")
+
+
+def test_update_node_and_delete_node_manage_entities(knowledge_graph: KnowledgeGraph, data_file: Path) -> None:
+    """Generic node updates should mutate stored entities and support removal."""
+    task_id = knowledge_graph.add_task({
+        "title": "Status report",
+        "description": "Share weekly update",
+        "tags": ["status"],
+    })
+
+    assert knowledge_graph.update_node(task_id, {"title": "Weekly status"}) is True
+    assert knowledge_graph.get_task(task_id)["title"] == "Weekly status"
+
+    assert knowledge_graph.delete_node(task_id) is True
+    assert knowledge_graph.get_task(task_id) is None
+
+    persisted = _load_persisted_data(data_file)
+    assert persisted["tasks"] == []
+
+
+def test_remove_all_relationships_clears_edges(knowledge_graph: KnowledgeGraph) -> None:
+    """Removing relationships should isolate the node from the graph."""
+    note_id = knowledge_graph.add_note({
+        "title": "Tag note",
+        "content": "",
+        "tags": ["shared"],
+    })
+    knowledge_graph.add_task({
+        "title": "Tag task",
+        "description": "",
+        "tags": ["shared"],
+    })
+
+    node_id = f"note_{note_id}"
+    assert list(knowledge_graph.graph.neighbors(node_id))  # ensure an edge exists
+
+    assert knowledge_graph.remove_all_relationships(note_id) is True
+    assert list(knowledge_graph.graph.neighbors(node_id)) == []
+
+
+def test_add_and_retrieve_document(knowledge_graph: KnowledgeGraph, data_file: Path) -> None:
+    """Documents should be persisted and retrievable like other entities."""
+    document_id = knowledge_graph.add_document({
+        "id": "doc1",
+        "title": "Spec",
+        "content": "Functional spec",
+        "tags": ["spec"],
+        "topics": ["architecture"],
+    })
+
+    stored = knowledge_graph.get_document(document_id)
+    assert stored["title"] == "Spec"
+
+    persisted = _load_persisted_data(data_file)
+    assert persisted["documents"][0]["id"] == "doc1"
+
+
+def test_find_path_raises_for_missing_nodes(knowledge_graph: KnowledgeGraph) -> None:
+    """Finding a path for unknown entities should raise an informative error."""
+    with pytest.raises(EntityNotFoundError):
+        knowledge_graph.find_path("missing", "note", "also-missing", "task")
+
+
+def test_remove_relationship_missing_node_returns_false(knowledge_graph: KnowledgeGraph) -> None:
+    """Removing relationships for a non-existent node should fail gracefully."""
+    assert knowledge_graph.remove_all_relationships("nonexistent") is False

--- a/tests/test_query_service.py
+++ b/tests/test_query_service.py
@@ -1,0 +1,65 @@
+"""Query service coverage for semantic and text search pathways."""
+from __future__ import annotations
+
+from typing import List
+
+from graph_space_v2.core.services.query_service import QueryService
+
+from tests.conftest import DummyEmbeddingService, DummyLLMService
+
+
+def _populate_sample_data(knowledge_graph) -> List[str]:
+    task_id = knowledge_graph.add_task({
+        "title": "Write docs",
+        "description": "Draft the API section",
+        "tags": ["docs"],
+    })
+    knowledge_graph.add_note({
+        "title": "Docs outline",
+        "content": "Remember to cover authentication",
+        "tags": ["docs"],
+    })
+    knowledge_graph.add_contact({
+        "name": "Alex Writer",
+        "email": "alex@example.com",
+        "organization": "Docs Guild",
+        "tags": ["docs"],
+    })
+    return [task_id]
+
+
+def test_text_search_ranks_entities(knowledge_graph) -> None:
+    """Text search should surface entities across all supported types."""
+    task_id = _populate_sample_data(knowledge_graph)[0]
+    service = QueryService(knowledge_graph)
+
+    results = service.text_search("docs")
+    result_types = {result["type"] for result in results}
+    assert {"note", "task", "contact"}.issubset(result_types)
+    assert any(result["id"] == task_id for result in results)
+
+
+def test_semantic_search_uses_embeddings(knowledge_graph, dummy_embedding_service: DummyEmbeddingService) -> None:
+    """Semantic search should delegate to the embedding service when available."""
+    task_id = _populate_sample_data(knowledge_graph)[0]
+    dummy_embedding_service.semantic_matches = [
+        {
+            "id": task_id,
+            "score": 0.95,
+            "metadata": {"type": "task"},
+        }
+    ]
+    service = QueryService(knowledge_graph, dummy_embedding_service, DummyLLMService())
+
+    results = service.semantic_search("docs")
+    assert results[0]["id"] == task_id
+    assert results[0]["type"] == "task"
+
+
+def test_semantic_search_falls_back_to_text(knowledge_graph) -> None:
+    """If embeddings are unavailable, semantic_search should reuse text search."""
+    _populate_sample_data(knowledge_graph)
+    service = QueryService(knowledge_graph, None, None)
+
+    results = service.semantic_search("authentication")
+    assert results  # falls back to text search

--- a/tests/test_task_model.py
+++ b/tests/test_task_model.py
@@ -1,0 +1,75 @@
+"""Tests covering the task domain model behaviour."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from graph_space_v2.core.models.task import Task
+
+
+def test_task_serialization_includes_domain_fields() -> None:
+    """Task.to_dict should include both base and domain-specific attributes."""
+    task = Task(
+        title="Draft proposal",
+        description="Prepare slide deck",
+        status=Task.STATUS_IN_PROGRESS,
+        due_date=datetime.now().isoformat(),
+        priority=Task.PRIORITY_HIGH,
+        tags=["planning"],
+        project="Q4",
+        is_recurring=True,
+        recurrence_frequency=Task.FREQUENCY_WEEKLY,
+        calendar_sync=True,
+        calendar_provider="google",
+    )
+
+    serialized = task.to_dict()
+
+    assert serialized["title"] == "Draft proposal"
+    assert serialized["status"] == Task.STATUS_IN_PROGRESS
+    assert serialized["project"] == "Q4"
+    assert serialized["calendar_sync"] is True
+    assert serialized["calendar_provider"] == "google"
+    assert serialized["is_recurring"] is True
+
+
+def test_task_mark_completed_updates_recurrence_schedule() -> None:
+    """Completing a recurring task should advance its next run and reset status."""
+    due = datetime.now() - timedelta(days=1)
+    task = Task(
+        title="Daily report",
+        description="Send the daily metrics",
+        due_date=due.isoformat(),
+        is_recurring=True,
+        recurrence_frequency=Task.FREQUENCY_DAILY,
+    )
+    previous_next_run = task.recurrence_next_run
+
+    task.mark_completed()
+
+    assert task.status == Task.STATUS_PENDING  # reset for the next occurrence
+    assert task.recurrence_next_run is not None
+    assert task.recurrence_next_run != previous_next_run
+    assert datetime.fromisoformat(task.recurrence_next_run) > due
+
+
+def test_task_update_applies_changes_and_refreshes_timestamp() -> None:
+    """Updating a task should mutate relevant fields and bump updated_at."""
+    task = Task(title="Initial")
+    original_updated_at = task.updated_at
+
+    task.update({
+        "title": "Updated",
+        "description": "New description",
+        "status": Task.STATUS_COMPLETED,
+        "tags": ["done"],
+        "project": "Revamp",
+        "calendar_sync": True,
+    })
+
+    assert task.title == "Updated"
+    assert task.description == "New description"
+    assert task.status == Task.STATUS_COMPLETED
+    assert task.tags == ["done"]
+    assert task.project == "Revamp"
+    assert task.calendar_sync is True
+    assert task.updated_at != original_updated_at

--- a/tests/test_task_service.py
+++ b/tests/test_task_service.py
@@ -1,0 +1,146 @@
+"""Task service behaviour under various workflows."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List
+
+import pytest
+
+from graph_space_v2.core.models.task import Task
+from graph_space_v2.core.services.task_service import TaskService
+
+from tests.conftest import DummyEmbeddingService, DummyLLMService
+
+
+@pytest.fixture()
+def task_service(knowledge_graph, dummy_embedding_service, dummy_llm_service):
+    """Create a TaskService wired to the in-memory stubs."""
+    return TaskService(knowledge_graph, dummy_embedding_service, dummy_llm_service)
+
+
+def test_add_task_uses_llm_and_embeddings(task_service: TaskService, knowledge_graph, dummy_embedding_service: DummyEmbeddingService, dummy_llm_service: DummyLLMService) -> None:
+    """Tasks added via dictionaries should be enriched by the LLM and embedded."""
+    task_id = task_service.add_task({
+        "description": "Prepare onboarding email",
+        "tags": [],
+    })
+
+    stored = knowledge_graph.get_task(task_id)
+    assert stored["title"].startswith("Title for")
+    assert dummy_embedding_service.stored_embeddings
+    assert dummy_llm_service.generated_titles == ["Prepare onboarding email"]
+
+
+def test_get_all_tasks_returns_models(task_service: TaskService) -> None:
+    """Fetching all tasks should yield Task instances."""
+    task_service.add_task({"title": "First", "description": ""})
+    task_service.add_task(Task(title="Second", description=""))
+
+    tasks = task_service.get_all_tasks()
+    assert all(isinstance(task, Task) for task in tasks)
+
+
+def test_update_task_refreshes_timestamp_and_embeddings(task_service: TaskService, knowledge_graph, dummy_embedding_service: DummyEmbeddingService) -> None:
+    """Updating a task should persist changes and refresh embeddings when needed."""
+    task_id = task_service.add_task({"title": "Initial", "description": "Alpha"})
+    original_updated_at = knowledge_graph.get_task(task_id)["updated_at"]
+
+    task_service.update_task(task_id, {"description": "Updated description"})
+
+    stored = knowledge_graph.get_task(task_id)
+    assert stored["description"] == "Updated description"
+    assert stored["updated_at"] != original_updated_at
+    assert dummy_embedding_service.updated_embeddings[task_id]["embedding"].endswith("Updated description")
+
+
+def test_mark_task_completed_and_in_progress(task_service: TaskService, knowledge_graph) -> None:
+    """Completion and status transitions should sync with the graph."""
+    task_id = task_service.add_task({"title": "Task", "description": ""})
+
+    completed = task_service.mark_task_completed(task_id)
+    assert completed is not None
+    assert knowledge_graph.get_task(task_id)["status"] == Task.STATUS_COMPLETED
+
+    restarted = task_service.mark_task_in_progress(task_id)
+    assert restarted is not None
+    assert knowledge_graph.get_task(task_id)["status"] == Task.STATUS_IN_PROGRESS
+
+
+def test_task_filters_and_queries(task_service: TaskService) -> None:
+    """Filtering helpers should return the expected subsets."""
+    task_service.add_task({
+        "title": "Pending",
+        "description": "",
+        "status": Task.STATUS_PENDING,
+        "project": "Alpha",
+        "tags": ["team"],
+    })
+    in_progress_id = task_service.add_task({
+        "title": "Active",
+        "description": "",
+        "status": Task.STATUS_IN_PROGRESS,
+        "priority": Task.PRIORITY_HIGH,
+        "due_date": (datetime.now() + timedelta(days=1)).isoformat(),
+        "tags": ["team"],
+        "project": "Alpha",
+    })
+    overdue_id = task_service.add_task({
+        "title": "Overdue",
+        "description": "",
+        "status": Task.STATUS_PENDING,
+        "due_date": (datetime.now() - timedelta(days=2)).isoformat(),
+        "tags": ["urgent"],
+        "project": "Beta",
+    })
+
+    assert {task.id for task in task_service.get_tasks_by_status(Task.STATUS_IN_PROGRESS)} == {in_progress_id}
+    assert {task.id for task in task_service.get_tasks_by_project("Alpha")} >= {in_progress_id}
+    assert {task.id for task in task_service.get_tasks_by_tag("team")}
+    assert {task.id for task in task_service.get_overdue_tasks()} == {overdue_id}
+    due_soon_ids = {task.id for task in task_service.get_tasks_due_soon(2)}
+    assert overdue_id not in due_soon_ids
+    assert in_progress_id in due_soon_ids
+
+
+def test_search_tasks_semantic_and_fallback(task_service: TaskService, dummy_embedding_service: DummyEmbeddingService) -> None:
+    """Semantic search should use embeddings when available and fall back otherwise."""
+    first_id = task_service.add_task({"title": "Documentation", "description": "Write API docs"})
+    task_service.add_task({"title": "Review", "description": "Review PR"})
+
+    dummy_embedding_service.semantic_matches = [
+        {"id": first_id, "score": 0.9, "snippet": "", "metadata": {"type": "task"}},
+    ]
+    semantic_results = task_service.search_tasks("docs")
+    assert semantic_results[0]["task"]["id"] == first_id
+
+    # Disable embeddings to trigger text search
+    plain_service = TaskService(task_service.knowledge_graph, None, None)
+    plain_results = plain_service.search_tasks("review")
+    assert plain_results[0]["task"]["title"] == "Review"
+
+
+def test_process_recurring_tasks_generates_instances(task_service: TaskService, knowledge_graph) -> None:
+    """Recurring tasks should spawn new tasks when the next run is due."""
+    recurring = Task(
+        title="Daily standup",
+        description="Post standup notes",
+        is_recurring=True,
+        recurrence_frequency=Task.FREQUENCY_DAILY,
+        recurrence_next_run=(datetime.now() - timedelta(minutes=5)).isoformat(),
+    )
+    knowledge_graph.add_task(recurring.to_dict())
+
+    new_tasks = task_service.process_recurring_tasks()
+    assert new_tasks
+    generated_tags: List[str] = new_tasks[0].tags
+    assert "generated_from_recurring" in generated_tags
+
+    updated_recurring = task_service.get_task(recurring.id)
+    assert updated_recurring.recurrence_next_run != recurring.recurrence_next_run
+
+
+def test_delete_task_removes_embeddings(task_service: TaskService, dummy_embedding_service: DummyEmbeddingService) -> None:
+    """Deleting a task should also clean up associated embeddings."""
+    task_id = task_service.add_task({"title": "Cleanup", "description": ""})
+    assert task_service.delete_task(task_id) is True
+    assert task_id in dummy_embedding_service.deleted_embeddings


### PR DESCRIPTION
## Summary
- add extensive pytest coverage for the knowledge graph, task service/model, query service, and GraphSpace integration while stubbing heavyweight dependencies
- harden task recurrence handling and deletion helpers by fixing TaskService Task inputs, recurring schedule calculation, and knowledge-graph node removal logic
- ignore Python cache artifacts to keep the repository clean

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68cc4e37ffa08325a5b65221aa3f5373